### PR TITLE
Part 2 - Add BookingPrices table

### DIFF
--- a/db/migrate/20240611150632_add_booking_prices.rb
+++ b/db/migrate/20240611150632_add_booking_prices.rb
@@ -1,0 +1,14 @@
+class AddBookingPrices < ActiveRecord::Migration[7.1]
+  def change
+    create_table :booking_prices do |t|
+      t.decimal :price, scale: 3, precision: 12
+
+      # Not using t.timestamps as there should be no time these are updated.
+      t.datetime :created_at, null: false
+
+      t.belongs_to :booking, null: false, foreign_key: true
+    end
+
+    add_index :booking_prices, :created_at, order: :desc
+  end
+end

--- a/db/migrate/20240611150632_add_booking_prices.rb
+++ b/db/migrate/20240611150632_add_booking_prices.rb
@@ -1,7 +1,7 @@
 class AddBookingPrices < ActiveRecord::Migration[7.1]
   def change
     create_table :booking_prices do |t|
-      t.decimal :price, scale: 3, precision: 12
+      t.decimal :price, scale: 3, precision: 12, null: false
 
       # Not using t.timestamps as there should be no time these are updated.
       t.datetime :created_at, null: false
@@ -9,6 +9,7 @@ class AddBookingPrices < ActiveRecord::Migration[7.1]
       t.belongs_to :booking, null: false, foreign_key: true
     end
 
+    # Index added to increase performance of future queries.
     add_index :booking_prices, :created_at, order: :desc
   end
 end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,9 +10,17 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2024_06_11_114211) do
+ActiveRecord::Schema[7.1].define(version: 2024_06_11_150632) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
+
+  create_table "booking_prices", force: :cascade do |t|
+    t.decimal "price", precision: 12, scale: 3
+    t.datetime "created_at", null: false
+    t.bigint "booking_id", null: false
+    t.index ["booking_id"], name: "index_booking_prices_on_booking_id"
+    t.index ["created_at"], name: "index_booking_prices_on_created_at", order: :desc
+  end
 
   create_table "bookings", force: :cascade do |t|
     t.integer "status", default: 0
@@ -38,6 +46,7 @@ ActiveRecord::Schema[7.1].define(version: 2024_06_11_114211) do
     t.index ["booking_id"], name: "index_modification_requests_on_booking_id"
   end
 
+  add_foreign_key "booking_prices", "bookings"
   add_foreign_key "cancellation_requests", "bookings"
   add_foreign_key "modification_requests", "bookings"
 end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -15,7 +15,7 @@ ActiveRecord::Schema[7.1].define(version: 2024_06_11_150632) do
   enable_extension "plpgsql"
 
   create_table "booking_prices", force: :cascade do |t|
-    t.decimal "price", precision: 12, scale: 3
+    t.decimal "price", precision: 12, scale: 3, null: false
     t.datetime "created_at", null: false
     t.bigint "booking_id", null: false
     t.index ["booking_id"], name: "index_booking_prices_on_booking_id"


### PR DESCRIPTION
## Solution Ideas

1. Add model level logic for `#price_changes` and amalgamating sales data by using `Booking.price` and Modify/Cancel record data. Given the requirements for additional tracking the fact that this is somewhat possible might be due to my dummy implementation more than this being a valid option. The main piece of information lost with this is the initial price of a booking if it is modified. 👎 
2. Add a new `PriceChange` model, with fields like new_price & old_price, time_of_change, possibly the cause of the change, like modification id or cancellation id.
3. Add a new `BookingPrice` model, which houses the price/price fields when they change. The most recent record could be used in the `guest_price` method on the Booking rather than calculating when we have a stored price. 👍 

Out of 2 & 3, I prefer 3 because a `PriceChange` record feels like a record purely for tracking purposes as opposed to `BookingPrice` is a segregation of data into another table that we can then use to track. `Booking.price_changes` can then be computed from the `booking_prices` if it needs to be different from just a price.

## Implementation

These are the steps I usually go through when adding new records:

1. To simply add the table to house the new information. It's added in a separate PR to avoid issues when rolling out or back future changes.
4. Roll out `Populating` the new price table
5. Roll out `Backfilling` the new price table
6. Roll out `Using` the new price table 